### PR TITLE
Demo：基于 Flink SQL 构建流式应用  连接不上Elasticsearch

### DIFF
--- a/questions.md
+++ b/questions.md
@@ -1,0 +1,48 @@
+Flink SQL> show tables;
+buy_cnt_per_hour
+cumulative_uv
+user_behavior
+uv_per_10min
+
+到这里是正常的。执行insert语句就开始报错,elasticsearch里面也没有创建索引，推测原因是flink没有连接到elasticsearch.
+如何解决呢？
+
+INSERT INTO buy_cnt_per_hour
+SELECT HOUR(TUMBLE_START(ts, INTERVAL '1' HOUR)), COUNT(*)
+FROM user_behavior
+WHERE behavior = 'buy'
+GROUP BY TUMBLE(ts, INTERVAL '1' HOUR);
+
+
+Flink SQL> select * from buy_cnt_per_hour;
+[ERROR] Could not execute SQL statement. Reason:
+org.apache.flink.table.api.NoMatchingTableFactoryException: Could not find a suitable table factory for 'org.apache.flink.table.factories.TableSourceFactory' in
+the classpath.
+
+Reason: Required context properties mismatch.
+
+The matching candidates:
+org.apache.flink.table.sources.CsvAppendTableSourceFactory
+Mismatched properties:
+'connector.type' expects 'filesystem', but is 'elasticsearch'
+'format.type' expects 'csv', but is 'json'
+
+The following properties are requested:
+connector.bulk-flush.max-actions=1
+connector.document-type=user_behavior
+connector.hosts=http://localhost:9200
+connector.index=buy_cnt_per_hour
+connector.type=elasticsearch
+connector.version=7
+format.type=json
+schema.0.data-type=BIGINT
+schema.0.name=hour_of_day
+schema.1.data-type=BIGINT
+schema.1.name=buy_cnt
+update-mode=append
+
+The following factories have been considered:
+org.apache.flink.api.java.io.jdbc.JDBCTableSourceSinkFactory
+org.apache.flink.streaming.connectors.kafka.KafkaTableSourceSinkFactory
+org.apache.flink.table.sources.CsvBatchTableSourceFactory
+org.apache.flink.table.sources.CsvAppendTableSourceFactory


### PR DESCRIPTION
我用docker练习这个demo，docker启动的服务有datagen,kafka,zookeeper,elasticsearch,mysql,kibana,datagen,kafka,zookeeper,elasticsearch,mysql,kibana,这几个服务都是正常的。flink单独启动，insert时报错，推测是因为flink连不上Elasticsearch。
另外，在我的环境下，建表语句'connector.version' = '7' 此处必须为7，否则报错。

CREATE TABLE buy_cnt_per_hour ( 
    hour_of_day BIGINT,
    buy_cnt BIGINT
) WITH (
    'connector.type' = 'elasticsearch', -- 使用 elasticsearch connector
    'connector.version' = '7',  -- elasticsearch 版本，6 能支持 es 6+ 以及 7+ 的版本
    'connector.hosts' = 'http://localhost:9200',  -- elasticsearch 地址
    'connector.index' = 'buy_cnt_per_hour',  -- elasticsearch 索引名，相当于数据库的表名
    'connector.document-type' = 'user_behavior', -- elasticsearch 的 type，相当于数据库的库名
    'connector.bulk-flush.max-actions' = '1',  -- 每条数据都刷新
    'format.type' = 'json',  -- 输出数据格式 json
    'update-mode' = 'append'
);